### PR TITLE
Update namespace in @contextdde-schema.jsonld

### DIFF
--- a/dde-schema.jsonld
+++ b/dde-schema.jsonld
@@ -3,8 +3,8 @@
     "schema": "http://schema.org/",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "creid": "https://discovery.biothings.io/view/creid/",
-    "niaid": "https://discovery.biothings.io/view/niaid/"
+    "creid": "https://discovery.biothings.io/ns/creid/",
+    "niaid": "https://discovery.biothings.io/ns/niaid/"
   },
   "@graph": [
     {


### PR DESCRIPTION
The DDE has changed the url stub for the name spaces from 'view' to 'ns'. The url in the @context of the niaid schema was updated on 2025.05.09. 

I recommend updating the urls in the creid schema as well.